### PR TITLE
Add reusable generic repository for crud services

### DIFF
--- a/MatfForum/src/Services/UserManagement/MatForum.UserManagement.API/Program.cs
+++ b/MatfForum/src/Services/UserManagement/MatForum.UserManagement.API/Program.cs
@@ -10,7 +10,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // Register services
-builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddSingleton<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
 
 builder.Services.AddControllers();

--- a/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Application/DTOs/UserDto.cs
+++ b/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Application/DTOs/UserDto.cs
@@ -14,6 +14,7 @@ public class UserDto
 
 public class CreateUserDto
 {
+    public Guid Id { get; set; }
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
@@ -23,9 +24,9 @@ public class CreateUserDto
 
 public class UpdateUserDto
 {
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
-    public string Username { get; set; } = string.Empty;
-    public DateTime DateOfBirth { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? Email { get; set; }
+    public string? Username { get; set; }
+    public DateTime? DateOfBirth { get; set; }
 } 

--- a/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Application/Interfaces/IUserRepository.cs
+++ b/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Application/Interfaces/IUserRepository.cs
@@ -1,13 +1,7 @@
-using MatForum.UserManagement.Application.DTOs;
 using MatForum.UserManagement.Domain.Entities;
+using MatForum.Shared.Domain.Interfaces;
 
 namespace MatForum.UserManagement.Application.Interfaces;
 
-public interface IUserRepository
-{
-    Task<User?> GetById(Guid id);
-    Task<IEnumerable<User>> GetAll();
-    Task<User> Create(User user);
-    Task<User?> Update(Guid id, User user);
-    Task<bool> Delete(Guid id);
-} 
+public interface IUserRepository: IGenericRepository<User>
+{} 

--- a/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Application/Services/UserService.cs
+++ b/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Application/Services/UserService.cs
@@ -31,6 +31,7 @@ public class UserService(IUserRepository userRepository) : IUserService
     {
         var user = new User
         {
+            Id = createUserDto.Id,
             FirstName = createUserDto.FirstName,
             LastName = createUserDto.LastName,
             Email = createUserDto.Email,
@@ -49,11 +50,11 @@ public class UserService(IUserRepository userRepository) : IUserService
             return null;
         }
         
-        existingUser.FirstName = updateUserDto.FirstName;
-        existingUser.LastName = updateUserDto.LastName;
-        existingUser.Email = updateUserDto.Email;
-        existingUser.Username = updateUserDto.Username;
-        existingUser.DateOfBirth = updateUserDto.DateOfBirth;
+        existingUser.FirstName = updateUserDto.FirstName ?? existingUser.FirstName;
+        existingUser.LastName = updateUserDto.LastName ?? existingUser.LastName;
+        existingUser.Email = updateUserDto.Email ?? existingUser.Email;
+        existingUser.Username = updateUserDto.Username ?? existingUser.Username;
+        existingUser.DateOfBirth = updateUserDto.DateOfBirth ?? existingUser.DateOfBirth;
         existingUser.UpdatedAt = DateTime.UtcNow;
 
         return await userRepository.Update(id, existingUser);

--- a/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Infrastructure/Repositories/UserRepository.cs
+++ b/MatfForum/src/Services/UserManagement/MatForum.UserManagement.Infrastructure/Repositories/UserRepository.cs
@@ -1,53 +1,8 @@
 using MatForum.UserManagement.Domain.Entities;
 using MatForum.UserManagement.Application.Interfaces;
+using MatForum.Shared.Infrastructure.Repositories;
 
 namespace MatForum.UserManagement.Infrastructure.Repositories;
 
-public class UserRepository : IUserRepository
-{
-    private static readonly List<User> Users = new();
-    
-    public async Task<User?> GetById(Guid id)
-    {
-        return await Task.FromResult(Users.FirstOrDefault(u => u.Id == id));
-    }
-    
-    public async Task<IEnumerable<User>> GetAll()
-    {
-        return await Task.FromResult(Users.AsEnumerable());
-    }
-    
-    public async Task<User> Create(User user)
-    {
-        if (user.Id == Guid.Empty)
-            user.Id = Guid.NewGuid();
-        
-        user.CreatedAt = DateTime.UtcNow;
-        user.UpdatedAt = DateTime.UtcNow;
-        
-        Users.Add(user);
-        return await Task.FromResult(user);
-    }
-    
-    public async Task<User?> Update(Guid id, User user)
-    {
-        var existingUserIndex = Users.FindIndex(u => u.Id == user.Id);
-        if (existingUserIndex >= 0)
-        {
-            user.UpdatedAt = DateTime.UtcNow;
-            Users[existingUserIndex] = user;
-        }
-        return await Task.FromResult(user);
-    }
-    
-    public async Task<bool> Delete(Guid id)
-    {
-        var user = Users.FirstOrDefault(u => u.Id == id);
-        if (user != null)
-        {
-            Users.Remove(user);
-        }
-        await Task.CompletedTask;
-        return true;
-    }
-}
+public class UserRepository : GenericRepository<User>, IUserRepository
+{}

--- a/MatfForum/src/Shared/MatForum.Shared.Domain/Common/BaseEntity.cs
+++ b/MatfForum/src/Shared/MatForum.Shared.Domain/Common/BaseEntity.cs
@@ -2,7 +2,7 @@ namespace MatForum.Shared.Domain.Common;
 
 public abstract class BaseEntity
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid Id { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/MatfForum/src/Shared/MatForum.Shared.Domain/Interfaces/IGenericRepository.cs
+++ b/MatfForum/src/Shared/MatForum.Shared.Domain/Interfaces/IGenericRepository.cs
@@ -1,0 +1,12 @@
+using MatForum.Shared.Domain.Common;
+
+namespace MatForum.Shared.Domain.Interfaces;
+
+public interface IGenericRepository<T> where T : BaseEntity
+{
+    Task<T?> GetById(Guid id);
+    Task<IEnumerable<T>> GetAll();
+    Task<T> Create(T entity);
+    Task<T?> Update(Guid id, T entity);
+    Task<bool> Delete(Guid id);
+} 

--- a/MatfForum/src/Shared/MatForum.Shared.Infrastructure/MatForum.Shared.Infrastructure.csproj
+++ b/MatfForum/src/Shared/MatForum.Shared.Infrastructure/MatForum.Shared.Infrastructure.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <ItemGroup>
+    <ProjectReference Include="..\MatForum.Shared.Domain\MatForum.Shared.Domain.csproj" />
+  </ItemGroup>
+  
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/MatfForum/src/Shared/MatForum.Shared.Infrastructure/Repositories/GenericRepository.cs
+++ b/MatfForum/src/Shared/MatForum.Shared.Infrastructure/Repositories/GenericRepository.cs
@@ -1,0 +1,80 @@
+using MatForum.Shared.Domain.Common;
+using MatForum.Shared.Domain.Interfaces;
+
+namespace MatForum.Shared.Infrastructure.Repositories;
+
+public abstract class GenericRepository<T> : IGenericRepository<T> where T : BaseEntity
+{
+    private readonly List<T> _entities = [];
+
+    public virtual async Task<T?> GetById(Guid id)
+    {
+        return await Task.FromResult(_entities.FirstOrDefault(e => e.Id == id));
+    }
+
+    public virtual async Task<IEnumerable<T>> GetAll()
+    {
+        return await Task.FromResult(_entities.AsEnumerable());
+    }
+
+    public virtual async Task<T> Create(T entity)
+    {
+        if (entity.Id == Guid.Empty)
+            entity.Id = Guid.NewGuid();
+        
+        if (_entities.Any(e => e.Id == entity.Id))
+        {
+            throw new InvalidOperationException($"Entity with ID {entity.Id} already exists.");
+        }
+        
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        
+        _entities.Add(entity);
+        return await Task.FromResult(entity);
+    }
+    
+    private static void UpdateEntityFields(T existing, T payload)
+    {
+        var properties = typeof(T).GetProperties()
+            .Where(property => property.CanWrite && 
+                               property.Name != nameof(BaseEntity.Id) &&
+                               property.Name != nameof(BaseEntity.CreatedAt) &&
+                               property.Name != nameof(BaseEntity.UpdatedAt));
+
+        foreach (var property in properties)
+        {
+            var payloadValue = property.GetValue(payload);
+            if (payloadValue != null)
+            {
+                property.SetValue(existing, payloadValue);
+            }
+        }
+    }
+
+    public virtual async Task<T?> Update(Guid id, T entity)
+    {
+        var index = _entities.FindIndex(e => e.Id == id);
+        if (index < 0)
+        {
+            return null;
+        }
+        
+        var existingEntity = _entities[index];
+        UpdateEntityFields(existingEntity, entity);
+        existingEntity.UpdatedAt = DateTime.UtcNow;
+        
+        return await Task.FromResult(existingEntity);
+    }
+
+    public virtual async Task<bool> Delete(Guid id)
+    {
+        var entity = _entities.FirstOrDefault(e => e.Id == id);
+        if (entity != null)
+        {
+            _entities.Remove(entity);
+            return await Task.FromResult(true);
+        }
+        return await Task.FromResult(false);
+    }
+}


### PR DESCRIPTION
Now every CRUD service can easily reuse this GenericRepository implementation by just extending IGenericRepository interface and GenericService implementation.