### PR TITLE
PostgresDB add 

### DIFF
--- a/MatfForum/docker-compose.yml
+++ b/MatfForum/docker-compose.yml
@@ -1,6 +1,19 @@
 version: '3.8'
 
 services:
+  postgres:
+    image: postgres:15
+    container_name: matforum-postgres
+    environment:
+      - POSTGRES_DB=matforum
+      - POSTGRES_USER=matforum_user
+      - POSTGRES_PASSWORD=matforum_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+    restart: on-failure
   user-service:
     build:
       context: .
@@ -21,8 +34,11 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:80
+      - ConnectionStrings__DefaultConnection=Host=postgres;Database=matforum;Username=matforum_user;Password=matforum_password
     ports:
       - "5002:80"
+    depends_on:
+      - postgres
     restart: on-failure
   
   voting-service:
@@ -33,6 +49,12 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:80
+      - ConnectionStrings__DefaultConnection=Host=postgres;Database=matforum;Username=matforum_user;Password=matforum_password
     ports:
       - "5003:80"
+    depends_on:
+      - postgres
     restart: on-failure
+
+volumes:
+  postgres_data:

--- a/MatfForum/init-db.sql
+++ b/MatfForum/init-db.sql
@@ -1,0 +1,77 @@
+-- MatForum Database Initialization Script
+-- This script creates the necessary tables for Question and Voting services
+
+-- Create Questions table
+CREATE TABLE IF NOT EXISTS "Questions" (
+    "Id" UUID PRIMARY KEY,
+    "Title" VARCHAR(500) NOT NULL,
+    "Content" TEXT NOT NULL,
+    "CreatedByUserId" UUID NOT NULL,
+    "CreatedDate" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "LastModifiedDate" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "Views" INTEGER NOT NULL DEFAULT 0,
+    "IsClosed" BOOLEAN NOT NULL DEFAULT FALSE,
+    "Tags" TEXT[], -- PostgreSQL array for tags
+    "CreatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "UpdatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create Votes table
+CREATE TABLE IF NOT EXISTS "Votes" (
+    "Id" UUID PRIMARY KEY,
+    "QuestionId" UUID NOT NULL,
+    "UserId" UUID NOT NULL,
+    "VoteType" INTEGER NOT NULL, -- -1 for downvote, 0 for neutral, 1 for upvote
+    "CreatedDate" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "LastModifiedDate" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "CreatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "UpdatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE("QuestionId", "UserId") -- Ensure one vote per user per question
+);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS IX_Questions_CreatedByUserId ON "Questions"("CreatedByUserId");
+CREATE INDEX IF NOT EXISTS IX_Questions_CreatedDate ON "Questions"("CreatedDate");
+CREATE INDEX IF NOT EXISTS IX_Questions_IsClosed ON "Questions"("IsClosed");
+CREATE INDEX IF NOT EXISTS IX_Questions_Views ON "Questions"("Views");
+
+CREATE INDEX IF NOT EXISTS IX_Votes_QuestionId ON "Votes"("QuestionId");
+CREATE INDEX IF NOT EXISTS IX_Votes_UserId ON "Votes"("UserId");
+CREATE INDEX IF NOT EXISTS IX_Votes_VoteType ON "Votes"("VoteType");
+
+-- Create a function to update the UpdatedAt timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.UpdatedAt = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Create triggers to automatically update UpdatedAt
+CREATE TRIGGER update_questions_updated_at 
+    BEFORE UPDATE ON "Questions" 
+    FOR EACH ROW 
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_votes_updated_at 
+    BEFORE UPDATE ON "Votes" 
+    FOR EACH ROW 
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Insert some sample data for testing
+INSERT INTO "Questions" ("Id", "Title", "Content", "CreatedByUserId", "CreatedDate", "LastModifiedDate", "Views", "IsClosed", "Tags") VALUES
+    ('550e8400-e29b-41d4-a716-446655440001', 'How to implement clean architecture?', 'I am new to clean architecture and would like to understand the best practices for implementing it in a .NET application.', '550e8400-e29b-41d4-a716-446655440010', NOW(), NOW(), 15, FALSE, ARRAY['architecture', 'clean-code', 'dotnet']),
+    ('550e8400-e29b-41d4-a716-446655440002', 'Best practices for microservices communication', 'What are the recommended patterns for communication between microservices in a distributed system?', '550e8400-e29b-41d4-a716-446655440011', NOW(), NOW(), 8, FALSE, ARRAY['microservices', 'communication', 'distributed-systems']),
+    ('550e8400-e29b-41d4-a716-446655440003', 'Entity Framework vs Dapper performance', 'I need to choose between Entity Framework and Dapper for my new project. What are the performance implications?', '550e8400-e29b-41d4-a716-446655440012', NOW(), NOW(), 23, FALSE, ARRAY['entity-framework', 'dapper', 'performance', 'orm'])
+ON CONFLICT ("Id") DO NOTHING;
+
+-- Insert some sample votes
+INSERT INTO "Votes" ("Id", "QuestionId", "UserId", "VoteType", "CreatedDate", "LastModifiedDate") VALUES
+    ('650e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440020', 1, NOW(), NOW()),
+    ('650e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440021', 1, NOW(), NOW()),
+    ('650e8400-e29b-41d4-a716-446655440003', '550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440022', -1, NOW(), NOW()),
+    ('650e8400-e29b-41d4-a716-446655440004', '550e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440020', 1, NOW(), NOW()),
+    ('650e8400-e29b-41d4-a716-446655440005', '550e8400-e29b-41d4-a716-446655440003', '550e8400-e29b-41d4-a716-446655440021', 1, NOW(), NOW()),
+    ('650e8400-e29b-41d4-a716-446655440006', '550e8400-e29b-41d4-a716-446655440003', '550e8400-e29b-41d4-a716-446655440022', 1, NOW(), NOW())
+ON CONFLICT ("QuestionId", "UserId") DO NOTHING;

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.API/Dockerfile
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.API/Dockerfile
@@ -1,10 +1,10 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/Services/ForumQuestion/MatForum.ForumQuestion.API/MatForum.ForumQuestion.API.csproj", "src/Services/ForumQuestion/MatForum.ForumQuestion.API/"]

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.API/MatForum.ForumQuestion.API.csproj
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.API/MatForum.ForumQuestion.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/DTOs/QuestionDto.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/DTOs/QuestionDto.cs
@@ -6,10 +6,10 @@ namespace MatForum.ForumQuestion.Application.DTOs
     public class QuestionDto
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+        public required string Title { get; set; }
+        public required string Content { get; set; }
         public Guid CreatedByUserId { get; set; }
-        public string AuthorName { get; set; }
+        public required string AuthorName { get; set; }
         public DateTimeOffset CreatedDate { get; set; }
         public DateTimeOffset LastModifiedDate { get; set; }
         public int Views { get; set; }
@@ -19,8 +19,8 @@ namespace MatForum.ForumQuestion.Application.DTOs
 
     public class CreateQuestionCommand
     {
-        public string Title { get; set; }
-        public string Content { get; set; }
+        public required string Title { get; set; }
+        public required string Content { get; set; }
         public Guid CreatedByUserId { get; set; }
         public List<string> Tags { get; set; } = new List<string>();
     }
@@ -28,8 +28,8 @@ namespace MatForum.ForumQuestion.Application.DTOs
     public class UpdateQuestionCommand
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+        public required string Title { get; set; }
+        public required string Content { get; set; }
         public List<string> Tags { get; set; } = new List<string>();
     }
 }

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/Interfaces/IForumQuestionService.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/Interfaces/IForumQuestionService.cs
@@ -8,7 +8,7 @@ namespace MatForum.ForumQuestion.Application.Interfaces
     public interface IForumQuestionService
     {
         Task<QuestionDto> CreateQuestion(CreateQuestionCommand command);
-        Task<QuestionDto> GetQuestionById(Guid id);
+        Task<QuestionDto?> GetQuestionById(Guid id);
         Task<IEnumerable<QuestionDto>> GetAllQuestions();
         Task<bool> UpdateQuestion(UpdateQuestionCommand command);
         Task<bool> DeleteQuestion(Guid id);

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/MatForum.ForumQuestion.Application.csproj
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/MatForum.ForumQuestion.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/Services/QuestionService.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Application/Services/QuestionService.cs
@@ -50,7 +50,7 @@ namespace MatForum.ForumQuestion.Application.Services
             };
         }
 
-        public async Task<QuestionDto> GetQuestionById(Guid id)
+        public async Task<QuestionDto?> GetQuestionById(Guid id)
         {
             var question = await _questionRepository.GetById(id);
             if (question == null) return null;

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Domain/Entities/Question.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Domain/Entities/Question.cs
@@ -14,7 +14,7 @@ public class Question : BaseEntity
     public List<string> Tags { get; private set; } = new List<string>();
 
     // Constructor for creating new questions
-    public Question(string title, string content, Guid createdByUserId, List<string> tags = null)
+    public Question(string title, string content, Guid createdByUserId, List<string>? tags = null)
     {
         if (string.IsNullOrWhiteSpace(title)) throw new ArgumentException("Title cannot be empty.", nameof(title));
         if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Content cannot be empty.", nameof(content));
@@ -32,7 +32,7 @@ public class Question : BaseEntity
     }
 
     // Methods for domain behavior
-    public void Update(string title, string content, List<string> tags = null)
+    public void Update(string title, string content, List<string>? tags = null)
     {
         if (string.IsNullOrWhiteSpace(title)) throw new ArgumentException("Title cannot be empty.", nameof(title));
         if (string.IsNullOrWhiteSpace(content)) throw new ArgumentException("Content cannot be empty.", nameof(content));

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Domain/MatForum.ForumQuestion.Domain.csproj
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Domain/MatForum.ForumQuestion.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/Data/QuestionDbContext.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/Data/QuestionDbContext.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using MatForum.ForumQuestion.Domain.Entities;
+
+namespace MatForum.ForumQuestion.Infrastructure.Data
+{
+    public class QuestionDbContext : DbContext
+    {
+        public QuestionDbContext(DbContextOptions<QuestionDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Question> Questions { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Question>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedNever(); // We generate GUIDs in the domain
+                
+                entity.Property(e => e.Title)
+                    .IsRequired()
+                    .HasMaxLength(500);
+                
+                entity.Property(e => e.Content)
+                    .IsRequired();
+                
+                entity.Property(e => e.CreatedByUserId)
+                    .IsRequired();
+                
+                entity.Property(e => e.CreatedDate)
+                    .IsRequired();
+                
+                entity.Property(e => e.LastModifiedDate)
+                    .IsRequired();
+                
+                entity.Property(e => e.Views)
+                    .IsRequired()
+                    .HasDefaultValue(0);
+                
+                entity.Property(e => e.IsClosed)
+                    .IsRequired()
+                    .HasDefaultValue(false);
+                
+                entity.Property(e => e.Tags)
+                    .HasColumnType("text[]"); // PostgreSQL array type
+                
+                entity.Property(e => e.CreatedAt)
+                    .IsRequired()
+                    .HasDefaultValueSql("NOW()");
+                
+                entity.Property(e => e.UpdatedAt)
+                    .IsRequired()
+                    .HasDefaultValueSql("NOW()");
+
+                // Create indexes
+                entity.HasIndex(e => e.CreatedByUserId);
+                entity.HasIndex(e => e.CreatedDate);
+                entity.HasIndex(e => e.IsClosed);
+                entity.HasIndex(e => e.Views);
+            });
+        }
+    }
+}

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/MatForum.ForumQuestion.Infrastructure.csproj
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/MatForum.ForumQuestion.Infrastructure.csproj
@@ -1,10 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\Shared\MatForum.Shared.Infrastructure\MatForum.Shared.Infrastructure.csproj" />

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/QuestionServiceHttpClient.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/QuestionServiceHttpClient.cs
@@ -1,5 +1,6 @@
 using MatForum.ForumQuestion.Application.Interfaces;
 using MatForum.ForumQuestion.Application.DTOs;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
@@ -28,9 +29,11 @@ namespace MatForum.ForumQuestion.Infrastructure
             return JsonSerializer.Deserialize<QuestionDto>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         }
 
-        public async Task<QuestionDto> GetQuestionById(Guid id)
+        public async Task<QuestionDto?> GetQuestionById(Guid id)
         {
             var response = await _httpClient.GetAsync($"api/questions/{id}");
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return null;
             response.EnsureSuccessStatusCode();
             var json = await response.Content.ReadAsStringAsync();
             return JsonSerializer.Deserialize<QuestionDto>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/Repositories/EfQuestionRepository.cs
+++ b/MatfForum/src/Services/ForumQuestion/MatForum.ForumQuestion.Infrastructure/Repositories/EfQuestionRepository.cs
@@ -1,0 +1,140 @@
+using Microsoft.EntityFrameworkCore;
+using MatForum.ForumQuestion.Application.Interfaces;
+using MatForum.ForumQuestion.Domain.Entities;
+using MatForum.ForumQuestion.Infrastructure.Data;
+using MatForum.Shared.Domain.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MatForum.ForumQuestion.Infrastructure.Repositories
+{
+    public class EfQuestionRepository : IQuestionRepository, IGenericRepository<Question>
+    {
+        private readonly QuestionDbContext _context;
+
+        public EfQuestionRepository(QuestionDbContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public async Task<Question> GetByIdAsync(Guid id)
+        {
+            return await _context.Questions
+                .FirstOrDefaultAsync(q => q.Id == id);
+        }
+
+        public async Task<IEnumerable<Question>> GetAllAsync()
+        {
+            return await _context.Questions
+                .OrderByDescending(q => q.CreatedDate)
+                .ToListAsync();
+        }
+
+        public async Task AddAsync(Question question)
+        {
+            if (question == null) throw new ArgumentNullException(nameof(question));
+            
+            _context.Questions.Add(question);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Question question)
+        {
+            if (question == null) throw new ArgumentNullException(nameof(question));
+            
+            _context.Questions.Update(question);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(Question question)
+        {
+            if (question == null) throw new ArgumentNullException(nameof(question));
+            
+            _context.Questions.Remove(question);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<IEnumerable<Question>> GetByUserIdAsync(Guid userId)
+        {
+            return await _context.Questions
+                .Where(q => q.CreatedByUserId == userId)
+                .OrderByDescending(q => q.CreatedDate)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<Question>> GetByTagAsync(string tag)
+        {
+            return await _context.Questions
+                .Where(q => q.Tags.Contains(tag.ToLowerInvariant()))
+                .OrderByDescending(q => q.CreatedDate)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<Question>> GetClosedQuestionsAsync()
+        {
+            return await _context.Questions
+                .Where(q => q.IsClosed)
+                .OrderByDescending(q => q.CreatedDate)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<Question>> GetOpenQuestionsAsync()
+        {
+            return await _context.Questions
+                .Where(q => !q.IsClosed)
+                .OrderByDescending(q => q.CreatedDate)
+                .ToListAsync();
+        }
+
+        // IGenericRepository<Question> implementation
+        public async Task<Question?> GetById(Guid id)
+        {
+            return await _context.Questions
+                .FirstOrDefaultAsync(q => q.Id == id);
+        }
+
+        public async Task<IEnumerable<Question>> GetAll()
+        {
+            return await _context.Questions
+                .OrderByDescending(q => q.CreatedDate)
+                .ToListAsync();
+        }
+
+        public async Task<Question> Create(Question entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+            
+            _context.Questions.Add(entity);
+            await _context.SaveChangesAsync();
+            return entity;
+        }
+
+        public async Task<Question?> Update(Guid id, Question entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+            
+            var existingQuestion = await _context.Questions.FindAsync(id);
+            if (existingQuestion == null)
+                return null;
+
+            // Update properties
+            existingQuestion.Update(entity.Title, entity.Content, entity.Tags);
+            
+            await _context.SaveChangesAsync();
+            return existingQuestion;
+        }
+
+        public async Task<bool> Delete(Guid id)
+        {
+            var question = await _context.Questions.FindAsync(id);
+            if (question == null)
+                return false;
+
+            _context.Questions.Remove(question);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+    }
+}

--- a/MatfForum/src/Services/Voting/MatForum.Voting.API/Program.cs
+++ b/MatfForum/src/Services/Voting/MatForum.Voting.API/Program.cs
@@ -1,6 +1,8 @@
 using MatForum.Voting.Application.Interfaces;
 using MatForum.Voting.Application.Services;
 using MatForum.Voting.Infrastructure.Repositories;
+using MatForum.Voting.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,11 +13,22 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Add Entity Framework
+builder.Services.AddDbContext<VotingDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
 // Register services
-builder.Services.AddScoped<IVoteRepository, InMemoryVoteRepository>();
+builder.Services.AddScoped<IVoteRepository, EfVoteRepository>();
 builder.Services.AddScoped<IVoteService, VoteService>();
 
 var app = builder.Build();
+
+// Ensure database is created
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<VotingDbContext>();
+    context.Database.EnsureCreated();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/MatfForum/src/Services/Voting/MatForum.Voting.Infrastructure/Data/VotingDbContext.cs
+++ b/MatfForum/src/Services/Voting/MatForum.Voting.Infrastructure/Data/VotingDbContext.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using MatForum.Voting.Domain.Entities;
+
+namespace MatForum.Voting.Infrastructure.Data
+{
+    public class VotingDbContext : DbContext
+    {
+        public VotingDbContext(DbContextOptions<VotingDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Vote> Votes { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Vote>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedNever(); // We generate GUIDs in the domain
+                
+                entity.Property(e => e.QuestionId)
+                    .IsRequired();
+                
+                entity.Property(e => e.UserId)
+                    .IsRequired();
+                
+                entity.Property(e => e.VoteType)
+                    .IsRequired()
+                    .HasConversion<int>(); // Convert enum to int
+                
+                entity.Property(e => e.CreatedDate)
+                    .IsRequired();
+                
+                entity.Property(e => e.LastModifiedDate)
+                    .IsRequired();
+                
+                entity.Property(e => e.CreatedAt)
+                    .IsRequired()
+                    .HasDefaultValueSql("NOW()");
+                
+                entity.Property(e => e.UpdatedAt)
+                    .IsRequired()
+                    .HasDefaultValueSql("NOW()");
+
+                // Create unique constraint for one vote per user per question
+                entity.HasIndex(e => new { e.QuestionId, e.UserId })
+                    .IsUnique();
+
+                // Create indexes for better performance
+                entity.HasIndex(e => e.QuestionId);
+                entity.HasIndex(e => e.UserId);
+                entity.HasIndex(e => e.VoteType);
+            });
+        }
+    }
+}

--- a/MatfForum/src/Services/Voting/MatForum.Voting.Infrastructure/MatForum.Voting.Infrastructure.csproj
+++ b/MatfForum/src/Services/Voting/MatForum.Voting.Infrastructure/MatForum.Voting.Infrastructure.csproj
@@ -7,7 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MatForum.Voting.Application\MatForum.Voting.Application.csproj" />
+    <ProjectReference Include="..\MatForum.Voting.Domain\MatForum.Voting.Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/MatfForum/src/Services/Voting/MatForum.Voting.Infrastructure/Repositories/EfVoteRepository.cs
+++ b/MatfForum/src/Services/Voting/MatForum.Voting.Infrastructure/Repositories/EfVoteRepository.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using MatForum.Voting.Application.Interfaces;
+using MatForum.Voting.Domain.Entities;
+using MatForum.Voting.Infrastructure.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MatForum.Voting.Infrastructure.Repositories
+{
+    public class EfVoteRepository : IVoteRepository
+    {
+        private readonly VotingDbContext _context;
+
+        public EfVoteRepository(VotingDbContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public async Task<Vote> GetByIdAsync(Guid id)
+        {
+            return await _context.Votes
+                .FirstOrDefaultAsync(v => v.Id == id);
+        }
+
+        public async Task<Vote> GetByQuestionAndUserAsync(Guid questionId, Guid userId)
+        {
+            return await _context.Votes
+                .FirstOrDefaultAsync(v => v.QuestionId == questionId && v.UserId == userId);
+        }
+
+        public async Task<IEnumerable<Vote>> GetByQuestionIdAsync(Guid questionId)
+        {
+            return await _context.Votes
+                .Where(v => v.QuestionId == questionId)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<Vote>> GetByUserIdAsync(Guid userId)
+        {
+            return await _context.Votes
+                .Where(v => v.UserId == userId)
+                .ToListAsync();
+        }
+
+        public async Task AddAsync(Vote vote)
+        {
+            if (vote == null) throw new ArgumentNullException(nameof(vote));
+            
+            _context.Votes.Add(vote);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Vote vote)
+        {
+            if (vote == null) throw new ArgumentNullException(nameof(vote));
+            
+            _context.Votes.Update(vote);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(Vote vote)
+        {
+            if (vote == null) throw new ArgumentNullException(nameof(vote));
+            
+            _context.Votes.Remove(vote);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<bool> ExistsAsync(Guid questionId, Guid userId)
+        {
+            return await _context.Votes
+                .AnyAsync(v => v.QuestionId == questionId && v.UserId == userId);
+        }
+    }
+}

--- a/MatfForum/src/Services/Voting/README.md
+++ b/MatfForum/src/Services/Voting/README.md
@@ -1,0 +1,288 @@
+# MatForum Voting Service
+
+A microservice for managing votes on forum questions in the MatForum application. This service handles upvoting, downvoting, and vote management for forum questions.
+
+## Overview
+
+The Voting Service provides a RESTful API for managing votes on forum questions. Users can upvote, downvote, change their votes, or remove their votes entirely. The service maintains vote statistics and provides endpoints for retrieving vote information.
+
+## Architecture
+
+This service follows Clean Architecture principles with the following layers:
+
+- **API Layer** (`MatForum.Voting.API`): Controllers and API endpoints
+- **Application Layer** (`MatForum.Voting.Application`): Business logic and services
+- **Domain Layer** (`MatForum.Voting.Domain`): Entities and domain models
+- **Infrastructure Layer** (`MatForum.Voting.Infrastructure`): Data access and repositories
+
+## Features
+
+- ✅ Vote on questions (upvote/downvote)
+- ✅ Change existing votes
+- ✅ Remove votes (set to neutral)
+- ✅ Get user's vote for a specific question
+- ✅ Get vote summary for questions
+- ✅ Get all votes for a question
+- ✅ In-memory data storage (for development)
+- ✅ Swagger API documentation
+
+## API Endpoints
+
+### Vote Management
+
+#### Vote on a Question
+```http
+POST /api/votes/vote
+Content-Type: application/json
+
+{
+  "questionId": "12345678-1234-1234-1234-123456789012",
+  "userId": "87654321-4321-4321-4321-210987654321",
+  "voteType": 1
+}
+```
+
+**Vote Types:**
+- `1` = Upvote
+- `-1` = Downvote
+
+#### Change Existing Vote
+```http
+PUT /api/votes/change
+Content-Type: application/json
+
+{
+  "questionId": "12345678-1234-1234-1234-123456789012",
+  "userId": "87654321-4321-4321-4321-210987654321",
+  "newVoteType": -1
+}
+```
+
+#### Remove Vote
+```http
+DELETE /api/votes/remove
+Content-Type: application/json
+
+{
+  "questionId": "12345678-1234-1234-1234-123456789012",
+  "userId": "87654321-4321-4321-4321-210987654321"
+}
+```
+
+### Vote Retrieval
+
+#### Get User's Vote
+```http
+GET /api/votes/user/{questionId}/{userId}
+```
+
+**Response:**
+```json
+{
+  "id": "vote-id",
+  "questionId": "12345678-1234-1234-1234-123456789012",
+  "userId": "87654321-4321-4321-4321-210987654321",
+  "voteType": 1,
+  "createdDate": "2025-09-06T13:26:04.3426175+00:00",
+  "lastModifiedDate": "2025-09-06T13:26:04.3426175+00:00"
+}
+```
+
+#### Get Vote Summary
+```http
+GET /api/votes/summary/{questionId}?userId={userId}
+```
+
+**Response:**
+```json
+{
+  "questionId": "12345678-1234-1234-1234-123456789012",
+  "totalUpvotes": 15,
+  "totalDownvotes": 3,
+  "netScore": 12,
+  "userVote": 1,
+  "totalVotes": 18
+}
+```
+
+#### Get All Votes for Question
+```http
+GET /api/votes/question/{questionId}
+```
+
+**Response:**
+```json
+[
+  {
+    "id": "vote1",
+    "questionId": "12345678-1234-1234-1234-123456789012",
+    "userId": "user1",
+    "voteType": 1,
+    "createdDate": "2025-09-06T13:26:04.3426175+00:00"
+  }
+]
+```
+
+## Getting Started
+
+### Prerequisites
+
+- .NET 8.0 SDK
+- Docker (optional)
+
+### Running Locally
+
+1. **Navigate to the API project:**
+   ```bash
+   cd src/Services/Voting/MatForum.Voting.API
+   ```
+
+2. **Restore dependencies:**
+   ```bash
+   dotnet restore
+   ```
+
+3. **Run the service:**
+   ```bash
+   dotnet run
+   ```
+
+4. **Access the API:**
+   - API: `http://localhost:5000`
+   - Swagger UI: `http://localhost:5000/swagger`
+
+### Running with Docker
+
+1. **From the project root:**
+   ```bash
+   docker-compose up voting-service
+   ```
+
+2. **Access the API:**
+   - API: `http://localhost:5003`
+   - Swagger UI: `http://localhost:5003/swagger`
+
+## Configuration
+
+### Environment Variables
+
+- `ASPNETCORE_ENVIRONMENT`: Set to `Development` or `Production`
+- `ASPNETCORE_URLS`: Override default URLs (default: `http://+:80`)
+
+### App Settings
+
+The service uses standard ASP.NET Core configuration. Key settings can be found in:
+- `appsettings.json` - Base configuration
+- `appsettings.Development.json` - Development-specific settings
+
+## Data Models
+
+### Vote Entity
+```csharp
+public class Vote
+{
+    public Guid Id { get; set; }
+    public Guid QuestionId { get; set; }
+    public Guid UserId { get; set; }
+    public int VoteType { get; set; } // 1 = upvote, -1 = downvote
+    public DateTime CreatedDate { get; set; }
+    public DateTime LastModifiedDate { get; set; }
+}
+```
+
+### DTOs
+
+- **VoteDto**: Vote data transfer object
+- **QuestionVoteSummaryDto**: Vote statistics for a question
+- **VoteQuestionCommand**: Command for voting
+- **ChangeVoteCommand**: Command for changing votes
+- **RemoveVoteCommand**: Command for removing votes
+
+## Error Handling
+
+The API returns appropriate HTTP status codes:
+
+- `200 OK` - Successful operation
+- `201 Created` - Vote created successfully
+- `204 No Content` - Vote removed successfully
+- `400 Bad Request` - Invalid request data
+- `404 Not Found` - Vote or question not found
+- `500 Internal Server Error` - Server error
+
+## Testing
+
+### Using cURL
+
+**Vote on a question:**
+```bash
+curl -X POST http://localhost:5003/api/votes/vote \
+  -H "Content-Type: application/json" \
+  -d '{
+    "questionId": "12345678-1234-1234-1234-123456789012",
+    "userId": "87654321-4321-4321-4321-210987654321",
+    "voteType": 1
+  }'
+```
+
+**Get vote summary:**
+```bash
+curl -X GET "http://localhost:5003/api/votes/summary/12345678-1234-1234-1234-123456789012"
+```
+
+### Using Swagger UI
+
+1. Navigate to `http://localhost:5003/swagger`
+2. Use the interactive API documentation to test endpoints
+3. Click "Try it out" on any endpoint to test it
+
+## Development
+
+### Project Structure
+
+```
+src/Services/Voting/
+├── MatForum.Voting.API/           # Web API project
+│   ├── Controllers/
+│   │   └── VotesController.cs     # API endpoints
+│   ├── Program.cs                 # Application startup
+│   └── appsettings.json          # Configuration
+├── MatForum.Voting.Application/   # Business logic
+│   ├── DTOs/                      # Data transfer objects
+│   ├── Interfaces/                # Service interfaces
+│   └── Services/                  # Business services
+├── MatForum.Voting.Domain/        # Domain entities
+│   └── Entities/
+│       └── Vote.cs               # Vote entity
+└── MatForum.Voting.Infrastructure/ # Data access
+    └── Repositories/
+        └── InMemoryVoteRepository.cs # In-memory storage
+```
+
+### Adding New Features
+
+1. **Domain Layer**: Add new entities or modify existing ones
+2. **Application Layer**: Add new services and DTOs
+3. **Infrastructure Layer**: Implement new repositories
+4. **API Layer**: Add new controllers and endpoints
+
+## Dependencies
+
+- **Microsoft.AspNetCore.OpenApi** (8.0.8) - OpenAPI support
+- **Swashbuckle.AspNetCore** (6.5.0) - Swagger documentation
+- **MatForum.Shared.Domain** - Shared domain models
+
+## Contributing
+
+1. Follow Clean Architecture principles
+2. Add unit tests for new features
+3. Update API documentation
+4. Follow C# coding conventions
+5. Update this README for significant changes
+
+## License
+
+This project is part of the MatForum application suite.
+
+## Support
+
+For issues and questions related to the Voting Service, please contact the development team or create an issue in the project repository.


### PR DESCRIPTION
## Summary

This PR integrates **PostgreSQL** into the project and updates the services that previously relied on the in-memory database.

## Changes

- Added **PostgreSQL database** configuration and connection.
- Updated **Question Service** to use PostgreSQL instead of in-memory storage.
- Updated **Voting Service** to use PostgreSQL instead of in-memory storage.
- Adjusted repository/DAO layers to support database persistence.
- Added migrations/SQL schema (if applicable).

## Why

- In-memory database was only suitable for testing/demo purposes.
- PostgreSQL provides persistence, scalability, and reliability.
- Prepares the project for production use.

## Testing

- Verified that questions can be created, retrieved, and stored persistently.
- Verified that voting functionality works correctly across sessions.
- Confirmed that data persists after server restart.

## Next Steps (Optional)

- Add unit/integration tests for PostgreSQL layer.
- Implement connection pooling and error handling improvements.
- Set up CI/CD with database migrations.

